### PR TITLE
Remove stale things

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add thing by url add-on for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -335,6 +335,7 @@ class ThingURLAdapter extends Adapter {
       res = await fetch(url, {headers: {Accept: 'application/json'}});
     } catch(e) {
       console.log('Failed to connect to', url, ':', e);
+      return;
     }
 
     let text = await res.text();
@@ -348,7 +349,13 @@ class ThingURLAdapter extends Adapter {
 
     this.knownUrls[url] = dig;
 
-    let data = JSON.parse(text);
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch(e) {
+      console.log('Failed to parse description at', url, ':', e);
+      return;
+    }
 
     let things;
     if (Array.isArray(data)) {


### PR DESCRIPTION
Instead of exiting if a url is known, check whether the downloaded thing
descriptions are known and refresh the things if necessary.

Note that depending on the frequency of mDNS/Eddystone pings it makes
more sense to drop knownUrls entirely and always refresh.

Fix #8.

There's still the issue I brought up in https://github.com/mozilla-iot/gateway/pull/755#discussion-diff-175197347L400 where you have to restart the Gateway to see a Thing if you remove it.