### PR TITLE
Cleanup websockets properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Add thing by url add-on for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -223,8 +223,15 @@ class ThingURLDevice extends Device {
       }
     });
 
-    this.ws.on('close', () => this.createWebsocket());
-    this.ws.on('error', () => this.createWebsocket());
+    const cleanupAndReopen = () => {
+      this.ws.removeAllListeners('close');
+      this.ws.removeAllListeners('error');
+      this.ws.close();
+      this.createWebsocket();
+    };
+
+    this.ws.on('close', cleanupAndReopen);
+    this.ws.on('error', cleanupAndReopen);
   }
 
   poll() {


### PR DESCRIPTION
Fix #17.

Solve an issue where the 'error' and 'close' event handlers would both
execute, create two websockets, then begin a constant loop of exploding.