### PR TITLE
Remove URL from config when deleting thing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Add thing by url add-on for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",


### PR DESCRIPTION
If a thing was added manually by URL, we need to delete it from
the config when the thing is removed.

Fixes #25