### PR TITLE
Change name and description to match add-on list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thing-url-adapter",
   "version": "0.1.7",
-  "description": "Add thing by url add-on for Mozilla IoT Gateway",
+  "description": "Native web thing support",
   "author": "Mozilla IoT",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Should we change the package metadata to match the name and description in the add-ons list?