### PR TITLE
Retry loadThing several times.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thing-url-adapter",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Native web thing support",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -357,14 +357,24 @@ class ThingURLAdapter extends Adapter {
     this.knownUrls = {};
   }
 
-  async loadThing(url) {
+  async loadThing(url, retryCounter) {
+    if (typeof retryCounter === 'undefined') {
+      retryCounter = 0;
+    }
+
     url = url.replace(/\/$/, '');
 
     let res;
     try {
       res = await fetch(url, {headers: {Accept: 'application/json'}});
     } catch (e) {
-      console.log('Failed to connect to', url, ':', e);
+      // Retry the connection at a 2 second interval up to 5 times.
+      if (retryCounter >= 5) {
+        console.log('Failed to connect to', url, ':', e);
+      } else {
+        setTimeout(() => this.loadThing(url, retryCounter + 1), 2000);
+      }
+
       return;
     }
 


### PR DESCRIPTION
Sometimes, a web thing can broadcast its mDNS advertisement before
the server has actually started listening, leading to a connection
failure. Retry a couple times to handle that.

Fixes #34