### PR TITLE
Check for proper Eddystone beacon type.

### DIFF
--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -548,8 +548,8 @@ class ThingURLAdapter extends Adapter {
 function startEddystoneDiscovery(adapter) {
   console.log('Starting Eddystone discovery');
 
-  EddystoneBeaconScanner.on('found', function(beacon) {
-    if (beacon.type === 'webthing') {
+  EddystoneBeaconScanner.on('found', (beacon) => {
+    if (beacon.type === 'url') {
       adapter.loadThing(beacon.url);
     }
   });


### PR DESCRIPTION
There are only 3 Eddystone beacon types. See:
https://github.com/sandeepmistry/node-eddystone-beacon-scanner/blob/master/lib/eddystone-beacon-scanner.js#L111