### PR TITLE
Add option to disable Bluetooth scanning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thing-url-adapter",
   "display_name": "Web Thing",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Native web thing support",
   "author": "Mozilla IoT",
   "main": "index.js",
@@ -40,7 +40,8 @@
     "schema": {
       "type": "object",
       "required": [
-        "urls"
+        "urls",
+        "bluetoothEnabled"
       ],
       "properties": {
         "urls": {
@@ -48,6 +49,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "bluetoothEnabled": {
+          "type": "boolean"
         }
       }
     }

--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -12,14 +12,10 @@ const crypto = require('crypto');
 const dnssd = require('dnssd');
 const fetch = require('node-fetch');
 const fs = require('fs');
-let EddystoneBeaconScanner;
-try {
-  EddystoneBeaconScanner = require('eddystone-beacon-scanner');
-} catch (e) {
-  console.warn('EddystoneBeaconScanner unsupported in current environment:', e);
-}
 const {URL} = require('url');
 const WebSocket = require('ws');
+
+let EddystoneBeaconScanner = null;
 
 const {
   Adapter,
@@ -669,7 +665,18 @@ function loadThingURLAdapter(addonManager, manifest, _errorCallback) {
     return;
   }
 
-  startEddystoneDiscovery(adapter);
+  if (typeof manifest.moziot.config.bluetoothEnabled === 'undefined' ||
+      manifest.moziot.config.bluetoothEnabled) {
+    try {
+      EddystoneBeaconScanner = require('eddystone-beacon-scanner');
+      startEddystoneDiscovery(adapter);
+    } catch (e) {
+      console.warn('EddystoneBeaconScanner unsupported in current environment:',
+                   e);
+    }
+  } else {
+    console.log('Disabling bluetooth scanning');
+  }
 }
 
 module.exports = loadThingURLAdapter;


### PR DESCRIPTION
Apparently, noble doesn't really play nicely with anything else,
including other instances of noble.

This will allow users to disable the (currently unused) Bluetooth
beacon scanner so that they can use Bluetooth for something else,
i.e. HomeKit devices.

Fixes mozilla-iot/gateway#1437