### PR TITLE
Websockets setproperty

### DIFF
--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -47,35 +47,35 @@ class ThingURLProperty extends Property {
    */
   setValue(value) {
     if (this.device.ws && this.device.ws.readyState === WebSocket.OPEN) {
-          const msg = {
-            messageType: Constants.SET_PROPERTY,
-            data: {[this.name]: value},
-          };
+      const msg = {
+        messageType: Constants.SET_PROPERTY,
+        data: {[this.name]: value},
+      };
 
-          this.device.ws.send(JSON.stringify(msg));
+      this.device.ws.send(JSON.stringify(msg));
       return Promise.resolve(value);
-    } else {
-      return fetch(this.url, {
-        method: 'PUT',
-        headers: {
+    }
+
+    return fetch(this.url, {
+      method: 'PUT',
+      headers: {
         'Content-type': 'application/json',
         Accept: 'application/json',
-        },
-        body: JSON.stringify({
+      },
+      body: JSON.stringify({
         [this.name]: value,
-        }),
-      }).then((res) => {
-        return res.json();
-      }).then((response) => {
-        const updatedValue = response[this.name];
-        this.setCachedValue(updatedValue);
-        this.device.notifyPropertyChanged(this);
-        return updatedValue;
-      }).catch((e) => {
-        console.log(`Failed to set ${this.name}: ${e}`);
-        return this.value;
-      });
-    }
+      }),
+    }).then((res) => {
+      return res.json();
+    }).then((response) => {
+      const updatedValue = response[this.name];
+      this.setCachedValue(updatedValue);
+      this.device.notifyPropertyChanged(this);
+      return updatedValue;
+    }).catch((e) => {
+      console.log(`Failed to set ${this.name}: ${e}`);
+      return this.value;
+    });
   }
 }
 


### PR DESCRIPTION
Add support for WebSocket for setting a property value, rather than using HTTP post. This is a _LOT_ faster. And conforms with a greater portion of the spec.