### PR TITLE
Barebones event support

### DIFF
--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -283,22 +283,7 @@ class ThingURLDevice extends Device {
           case Constants.EVENT: {
             const eventName = Object.keys(msg.data)[0];
             const event = msg.data[eventName];
-            const eventId = (event.data && event.data.hasOwnProperty('id')) ?
-              event.data.id :
-              `${eventName}-${event.timestamp}`;
-
-            if (!this.notifiedEvents.has(eventId)) {
-              if (!event.hasOwnProperty('timestamp')) {
-                event.timestamp = new Date().toISOString();
-              }
-              this.notifiedEvents.add(eventId);
-              const e = new Event(this,
-                                  eventName,
-                                  event.data || null);
-              e.timestamp = event.timestamp;
-
-              this.eventNotify(e);
-            }
+            this.createEvent(eventName, event);
             break;
           }
         }
@@ -385,20 +370,7 @@ class ThingURLDevice extends Device {
         for (let event of events) {
           const eventName = Object.keys(event)[0];
           event = event[eventName];
-          const eventId = (event.data && event.data.hasOwnProperty('id')) ?
-            event.data.id :
-            `${eventName}-${event.timestamp}`;
-
-          if (!this.notifiedEvents.has(eventId)) {
-            if (!event.hasOwnProperty('timestamp')) {
-              event.timestamp = new Date().toISOString();
-            }
-            this.notifiedEvents.add(eventId);
-            const e = new Event(this, eventName, event.data || null);
-            e.timestamp = event.timestamp;
-
-            this.eventNotify(e);
-          }
+          this.createEvent(eventName, event);
         }
       }).catch((e) => {
         console.log(`Failed to fetch events list: ${e}`);
@@ -409,6 +381,26 @@ class ThingURLDevice extends Device {
       clearTimeout(this.scheduledUpdate);
     }
     this.scheduledUpdate = setTimeout(() => this.poll(), this.updateInterval);
+  }
+
+  createEvent(eventName, event) {
+    const eventId = (event.data && event.data.hasOwnProperty('id')) ?
+      event.data.id :
+      `${eventName}-${event.timestamp}`;
+
+    if (this.notifiedEvents.has(eventId)) {
+      return;
+    }
+    if (!event.hasOwnProperty('timestamp')) {
+      event.timestamp = new Date().toISOString();
+    }
+    this.notifiedEvents.add(eventId);
+    const e = new Event(this,
+                        eventName,
+                        event.data || null);
+    e.timestamp = event.timestamp;
+
+    this.eventNotify(e);
   }
 
   performAction(action) {

--- a/thing-url-adapter.js
+++ b/thing-url-adapter.js
@@ -282,17 +282,22 @@ class ThingURLDevice extends Device {
           }
           case Constants.EVENT: {
             const eventName = Object.keys(msg.data)[0];
-            const eventId =
-              `${eventName}-${msg.data[eventName].timestamp}`;
+            const event = msg.data[eventName];
+            const eventId = (event.data && event.data.hasOwnProperty('id')) ?
+              event.data.id :
+              `${eventName}-${event.timestamp}`;
 
             if (!this.notifiedEvents.has(eventId)) {
+              if (!event.hasOwnProperty('timestamp')) {
+                event.timestamp = new Date().toISOString();
+              }
               this.notifiedEvents.add(eventId);
-              const event = new Event(this,
-                                      eventName,
-                                      msg.data[eventName].data || null);
-              event.timestamp = msg.data[eventName].timestamp;
+              const e = new Event(this,
+                                  eventName,
+                                  event.data || null);
+              e.timestamp = event.timestamp;
 
-              this.eventNotify(event);
+              this.eventNotify(e);
             }
             break;
           }
@@ -380,9 +385,14 @@ class ThingURLDevice extends Device {
         for (let event of events) {
           const eventName = Object.keys(event)[0];
           event = event[eventName];
-          const eventId = `${eventName}-${event.timestamp}`;
+          const eventId = (event.data && event.data.hasOwnProperty('id')) ?
+            event.data.id :
+            `${eventName}-${event.timestamp}`;
 
           if (!this.notifiedEvents.has(eventId)) {
+            if (!event.hasOwnProperty('timestamp')) {
+              event.timestamp = new Date().toISOString();
+            }
             this.notifiedEvents.add(eventId);
             const e = new Event(this, eventName, event.data || null);
             e.timestamp = event.timestamp;


### PR DESCRIPTION
Allows events without a timestamp to instead provide a unique ID and get one assigned by the gateway. Useful for embedded devices without an RTC.